### PR TITLE
fix: add build process on cd.yaml

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -7,6 +7,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build app
+        run: npm run build # 업로드 할 빌드 파일 생성
+
       - uses: actions/upload-artifact@v3 # 빌드 결과물을 업로드하고 다운가능한 상태로 보여주는 액션
         with:
           name: built-artifact


### PR DESCRIPTION
 build 파일 부재로 인한 cd.yaml 스크립트 실행 중 fail 발생. build 로직 보완.